### PR TITLE
enhancement: prevent ssr flicker on initial render

### DIFF
--- a/packages/react-plock/src/Plock.tsx
+++ b/packages/react-plock/src/Plock.tsx
@@ -5,7 +5,7 @@ export function useMediaValues(
   columns: number[],
   gap: number[]
 ) {
-  const [values, setValues] = React.useState({ columns: 1, gap: 1 });
+  const [values, setValues] = React.useState({ columns: 0, gap: 0 });
 
   React.useEffect(() => {
     if (!medias) {
@@ -74,6 +74,8 @@ export function Masonry<T>({
     createSafeArray(config.columns),
     createSafeArray(config.gap)
   );
+
+  if (!columns) return null;
 
   const chunks = createChunks<T>(items, columns);
   const dataColumns = createDataColumns<T>(chunks, columns);


### PR DESCRIPTION
Hello there! 👋 
Thank you for your amazing work on the library, it was exactly what I needed for a project at the right time.

I'm currently using `react-plock` with NextJs (`v13.2.1`) and the new `app` directory. Even though my masonry is a [client component](https://beta.nextjs.org/docs/rendering/server-and-client-components#client-components) it still flickers when loading because columns is always `1` on initial render. This leads to some annoying content layout shift that I prevented by copying the `react-plock` source code onto a file and setting initial columns to `0`. An early return prevents any rendering and problem solved. There is no performance issue as far as I can tell and the behaviour is exactly what it's expected.

I don't know if you encountered this problem before or if this is the best solution but I'm happy to figure this out together.

Let me know if you have any comments!